### PR TITLE
cmake: set required cmake required version to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.23)
 
 project("aos_core_common_cpp")
 


### PR DESCRIPTION
This patch updates the cmake required version to 3.23 because recent changes in core lib require features added in this version (target_sources FILE_SET).