### PR TITLE
ci: set SonarQube version to 5.3.0

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install SonarQube build wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5.3.0
 
 
       - name: Build (Release)
@@ -69,7 +69,7 @@ jobs:
 
       - name: SonarQube analysis (on push)
         if: github.event_name == 'push'
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v5.3.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: SonarQube analysis (on pull request)
         if: github.event_name == 'pull_request_target'
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v5.3.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release 5.3.1 introduced changes that break SonarQube action argument parsing.