### PR TITLE
launcher: runtime: handle relative device symlink

### DIFF
--- a/src/sm/launcher/runtime.cpp
+++ b/src/sm/launcher/runtime.cpp
@@ -156,7 +156,12 @@ oci::LinuxDevice DeviceFromPath(const fs::path& path)
     auto devPath = path;
 
     if (fs::is_symlink(path)) {
-        devPath = fs::read_symlink(path);
+        auto target = fs::read_symlink(path);
+        if (target.is_relative()) {
+            devPath = (path.parent_path() / target).lexically_normal();
+        } else {
+            devPath = target;
+        }
     }
 
     struct stat sb;

--- a/src/sm/launcher/tests/CMakeLists.txt
+++ b/src/sm/launcher/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCES runtime.cpp)
 # Libraries
 # ######################################################################################################################
 
-set(LIBRARIES aos::sm::launcher GTest::gmock_main)
+set(LIBRARIES aos::sm::launcher aos::core::common::tests::utils GTest::gmock_main)
 
 # ######################################################################################################################
 # Target

--- a/src/sm/launcher/tests/runtime.cpp
+++ b/src/sm/launcher/tests/runtime.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <core/common/tests/utils/log.hpp>
+#include <core/common/tests/utils/utils.hpp>
 
 #include <sm/launcher/runtime.hpp>
 
@@ -76,6 +77,58 @@ TEST_F(LauncherTest, CreateHostFSWhiteouts)
 
         EXPECT_EQ(hostBinds.Find(item.c_str()), hostBinds.end());
     }
+}
+
+TEST_F(LauncherTest, PopulateHostDevices)
+{
+    const auto cRootDevicePath     = fs::path(cTestDirRoot) / "dev";
+    const auto cTestDeviceFullPath = cRootDevicePath / "device1";
+
+    if (!fs::exists(cRootDevicePath)) {
+        fs::create_directories(cRootDevicePath);
+    }
+
+    if (auto res = mknod(cTestDeviceFullPath.c_str(), S_IFCHR, 0); res != 0) {
+        FAIL() << "Can't create test device node: " << strerror(errno);
+    }
+
+    StaticArray<oci::LinuxDevice, 1> devices;
+
+    auto err = mRuntime.PopulateHostDevices(cTestDeviceFullPath.c_str(), devices);
+    EXPECT_TRUE(err.IsNone()) << "failed: " << tests::utils::ErrorToStr(err);
+
+    EXPECT_EQ(devices.Size(), 1);
+    EXPECT_STREQ(devices.Front().mPath.CStr(), cTestDeviceFullPath.c_str());
+}
+
+TEST_F(LauncherTest, PopulateHostDevicesSymlink)
+{
+    const auto cRootDevicePath     = fs::path(cTestDirRoot) / "dev";
+    const auto cTestDeviceFullPath = cRootDevicePath / "device1";
+
+    if (!fs::exists(cRootDevicePath)) {
+        fs::create_directories(cRootDevicePath);
+    }
+
+    if (auto res = mknod(cTestDeviceFullPath.c_str(), S_IFCHR, 0); res != 0) {
+        FAIL() << "Can't create test device node: " << strerror(errno);
+    }
+
+    const auto currentPath = fs::current_path();
+
+    fs::current_path(cRootDevicePath);
+
+    fs::create_symlink("device1", "link");
+
+    fs::current_path(currentPath);
+
+    StaticArray<oci::LinuxDevice, 1> devices;
+
+    auto err = mRuntime.PopulateHostDevices((cRootDevicePath / "link").c_str(), devices);
+    EXPECT_TRUE(err.IsNone()) << "failed: " << tests::utils::ErrorToStr(err);
+
+    EXPECT_EQ(devices.Size(), 1);
+    EXPECT_STREQ(devices.Front().mPath.CStr(), cTestDeviceFullPath.c_str());
 }
 
 } // namespace aos::sm::launcher


### PR DESCRIPTION
This patch fixes operation not permitted error when the device path is a relative symlink. The fix resolves the symlink to an absolute path before calling stat().


Reviewed-by: Mykola Kobets <mykola_kobets@epam.com>
Reviewed-by: Mykola Solianko <mykola_solianko@epam.com>
Reviewed-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>