### PR TITLE
ocispec: add JSON string parsing methods

### DIFF
--- a/src/common/ocispec/ocispec.hpp
+++ b/src/common/ocispec/ocispec.hpp
@@ -23,7 +23,16 @@ public:
      * @param descriptor[out]  content descriptor.
      * @return Error.
      */
-    Error LoadContentDescriptor(const String& path, aos::oci::ContentDescriptor& descriptor) override;
+    Error ContentDescriptorFromFile(const String& path, aos::oci::ContentDescriptor& descriptor) override;
+
+    /**
+     * Loads OCI content descriptor from json string.
+     *
+     * @param json json string.
+     * @param descriptor[out]  content descriptor.
+     * @return Error.
+     */
+    Error ContentDescriptorFromJSON(const String& json, aos::oci::ContentDescriptor& descriptor) override;
 
     /**
      * Saves OCI content descriptor.
@@ -59,7 +68,16 @@ public:
      * @param[out] imageSpec image spec.
      * @return Error.
      */
-    Error LoadImageSpec(const String& path, aos::oci::ImageSpec& imageSpec) override;
+    Error ImageSpecFromFile(const String& path, aos::oci::ImageSpec& imageSpec) override;
+
+    /**
+     * Loads OCI image spec from json string.
+     *
+     * @param json json string.
+     * @param[out] imageSpec image spec.
+     * @return Error.
+     */
+    Error ImageSpecFromJSON(const String& json, aos::oci::ImageSpec& imageSpec) override;
 
     /**
      * Saves OCI image spec.
@@ -95,7 +113,16 @@ public:
      * @param serviceConfig service config.
      * @return Error.
      */
-    Error LoadServiceConfig(const String& path, aos::oci::ServiceConfig& serviceConfig) override;
+    Error ServiceConfigFromFile(const String& path, aos::oci::ServiceConfig& serviceConfig) override;
+
+    /**
+     * Loads Aos service config from json string.
+     *
+     * @param json json string.
+     * @param serviceConfig service config.
+     * @return Error.
+     */
+    Error ServiceConfigFromJSON(const String& json, aos::oci::ServiceConfig& serviceConfig) override;
 
     /**
      * Saves Aos service config.

--- a/src/sm/image/imagehandler.cpp
+++ b/src/sm/image/imagehandler.cpp
@@ -177,7 +177,7 @@ RetWithError<StaticString<cFilePathLen>> ImageHandler::InstallLayer(const String
     auto contentDescriptor = std::make_unique<oci::ContentDescriptor>();
     auto manifestPath      = std::filesystem::path(extractDir) / cLayerManifestFile;
 
-    if (err = mOCISpec->LoadContentDescriptor(manifestPath.c_str(), *contentDescriptor); !err.IsNone()) {
+    if (err = mOCISpec->ContentDescriptorFromFile(manifestPath.c_str(), *contentDescriptor); !err.IsNone()) {
         result.mError = AOS_ERROR_WRAP(Error(err, "failed to load content descriptor"));
         return result;
     }
@@ -334,7 +334,7 @@ Error ImageHandler::ValidateServiceConfig(const String& path, const String& dige
 
     auto serviceConfig = std::make_unique<oci::ServiceConfig>();
 
-    if (auto err = mOCISpec->LoadServiceConfig(serviceConfigPath.c_str(), *serviceConfig); !err.IsNone()) {
+    if (auto err = mOCISpec->ServiceConfigFromFile(serviceConfigPath.c_str(), *serviceConfig); !err.IsNone()) {
         return AOS_ERROR_WRAP(Error(err, "failed to load service config"));
     }
 

--- a/src/sm/image/tests/imagehandler.cpp
+++ b/src/sm/image/tests/imagehandler.cpp
@@ -345,7 +345,7 @@ TEST_F(ImageTest, InstallLayer)
 
     UniquePtr<aos::spaceallocator::SpaceItf> space;
 
-    EXPECT_CALL(mOCISpec, LoadContentDescriptor)
+    EXPECT_CALL(mOCISpec, ContentDescriptorFromFile)
         .WillOnce(Invoke([&archiveMetadata](const String&, oci::ContentDescriptor& descriptor) {
             descriptor.mDigest = "sha256:";
             descriptor.mDigest.Append(archiveMetadata.mEmbeddedArchiveDigest.c_str());
@@ -405,7 +405,7 @@ TEST_F(ImageTest, InstallService)
             return ErrorEnum::eNone;
         }));
 
-    EXPECT_CALL(mOCISpec, LoadServiceConfig).Times(1);
+    EXPECT_CALL(mOCISpec, ServiceConfigFromFile).Times(1);
 
     const auto installRoot = std::filesystem::path(cTestDirRoot) / "install" / "services";
     const auto serviceInfo = CreateServiceInfo(archiveMetadata);


### PR DESCRIPTION
Implement ContentDescriptorFromJSON, ImageSpecFromJSON, and ServiceConfigFromJSON methods to parse OCI spec objects directly from JSON strings. Refactor existing file parsing methods to use shared helper functions that extract common parsing logic.