### PR TITLE
sm: launcher: rootfs: fix preinstalled handling

### DIFF
--- a/src/common/pbconvert/sm.cpp
+++ b/src/common/pbconvert/sm.cpp
@@ -1043,6 +1043,8 @@ Error ConvertFromProto(const servicemanager::v5::InstanceStatus& src, const Stri
         return AOS_ERROR_WRAP(err);
     }
 
+    dst.mPreinstalled = src.preinstalled();
+
     dst.mError = pbconvert::ConvertFromProto(src.error());
 
     return ErrorEnum::eNone;

--- a/src/common/pbconvert/tests/sm.cpp
+++ b/src/common/pbconvert/tests/sm.cpp
@@ -197,6 +197,7 @@ TEST_F(PBConvertSMTest, ConvertInstanceStatusFromProto)
     grpcStatus.set_version("2.0.0");
     grpcStatus.set_runtime_id("runc");
     grpcStatus.set_state("active");
+    grpcStatus.set_preinstalled(true);
 
     auto* envVarStatus1 = grpcStatus.add_env_vars();
     envVarStatus1->set_name("VAR1");
@@ -221,6 +222,7 @@ TEST_F(PBConvertSMTest, ConvertInstanceStatusFromProto)
     EXPECT_EQ(aosStatus.mNodeID, String("node1"));
     EXPECT_EQ(aosStatus.mRuntimeID, String("runc"));
     EXPECT_EQ(aosStatus.mState, InstanceStateEnum::eActive);
+    EXPECT_TRUE(aosStatus.mPreinstalled);
     EXPECT_TRUE(aosStatus.mError.IsNone());
 
     ASSERT_EQ(aosStatus.mEnvVarsStatuses.Size(), 2);

--- a/src/sm/launcher/runtimes/rootfs/rootfs.hpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.hpp
@@ -7,6 +7,7 @@
 #ifndef AOS_SM_LAUNCHER_RUNTIMES_ROOTFS_ROOTFS_HPP_
 #define AOS_SM_LAUNCHER_RUNTIMES_ROOTFS_ROOTFS_HPP_
 
+#include <filesystem>
 #include <mutex>
 #include <thread>
 
@@ -144,25 +145,26 @@ private:
     using ActionTypeEnum = ActionTypeType::Enum;
     using ActionType     = EnumStringer<ActionTypeType>;
 
-    void  RunHealthCheck(std::unique_ptr<InstanceStatus> status);
-    Error InitInstalledData();
-    Error InitPendingData();
-    Error CreateRuntimeInfo();
-    Error ProcessUpdateAction(Array<InstanceStatus>& statuses);
-    Error ProcessUpdated(Array<InstanceStatus>& statuses);
-    Error ProcessFailed(Array<InstanceStatus>& statuses);
-    Error ProcessNoAction(Array<InstanceStatus>& statuses);
-    void  FillInstanceStatus(
-         const InstanceInfo& instanceInfo, const String& version, InstanceStateEnum state, InstanceStatus& status) const;
-    Error      SavePendingInstanceInfo(const InstanceInfo& instance, const String& version);
-    Error      LoadInstanceInfo(const String& path, InstanceInfo& instance, String& version);
-    Error      GetImageManifest(const String& digest, oci::ImageManifest& manifest) const;
-    Error      UnpackImage(const oci::ImageManifest& manifest) const;
-    Error      PrepareUpdateFileContent(const oci::ImageManifest& manifest, std::string& updateType) const;
-    void       ClearUpdateArtifacts() const;
-    Error      StoreAction(const ActionType& action, const std::string& data = "") const;
-    ActionType ReadAction() const;
-    Error      PrepareUpdate(const InstanceInfo& instance);
+    void                                    RunHealthCheck(std::unique_ptr<InstanceStatus> status);
+    RetWithError<StaticString<cVersionLen>> GetCurrentVersion() const;
+    Error                                   InitInstalledData();
+    Error                                   InitPendingData();
+    Error                                   CreateRuntimeInfo();
+    Error                                   ProcessUpdateAction(Array<InstanceStatus>& statuses);
+    Error                                   ProcessUpdated(Array<InstanceStatus>& statuses);
+    Error                                   ProcessFailed(Array<InstanceStatus>& statuses);
+    Error                                   ProcessNoAction(Array<InstanceStatus>& statuses);
+    void  FillInstanceStatus(const InstanceInfo& instanceInfo, InstanceStateEnum state, InstanceStatus& status) const;
+    Error SaveInstanceInfo(const InstanceInfo& instance, const std::filesystem::path& path) const;
+    Error LoadInstanceInfo(const std::filesystem::path& path, InstanceInfo& instance);
+    Error GetImageManifest(const String& digest, oci::ImageManifest& manifest) const;
+    Error UnpackImage(const oci::ImageManifest& manifest) const;
+    Error PrepareUpdateFileContent(const oci::ImageManifest& manifest, std::string& updateType) const;
+    void  ClearUpdateArtifacts() const;
+    Error StoreAction(const ActionType& action, const std::string& data = "") const;
+    ActionType            ReadAction() const;
+    Error                 PrepareUpdate(const InstanceInfo& instance);
+    std::filesystem::path GetPath(const std::string& fileName) const;
 
     RuntimeConfig                          mRuntimeConfig;
     RootfsConfig                           mRootfsConfig;
@@ -175,7 +177,7 @@ private:
 
     mutable std::mutex         mMutex;
     std::optional<std::thread> mHealthCheckThread;
-    InstanceInfo               mCurrentInstance;
+    InstanceInfo               mCurrentInstance {};
     StaticString<cVersionLen>  mCurrentVersion;
     RuntimeInfo                mRuntimeInfo;
     InstanceInfo               mPendingInstance;


### PR DESCRIPTION
This patch improves default instance handling:
- fixed missed preinstalled flag setting on StartInstance call;
- trimmed quotation marks from version string read from version file;
- installed instance json is stored on module start if; such file does not exist.