### PR TITLE
sm: launcher: runtimes: boot: set preinstalled instance ident

### DIFF
--- a/src/sm/launcher/runtimes/rootfs/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.cpp
@@ -257,8 +257,8 @@ Error RootfsRuntime::InitInstalledData()
             return err;
         }
 
-        mCurrentInstance.mType    = UpdateItemTypeEnum::eComponent;
-        mCurrentInstance.mVersion = version;
+        static_cast<InstanceIdent&>(mCurrentInstance) = mDefaultInstanceIdent;
+        mCurrentInstance.mVersion                     = version;
 
         err = SaveInstanceInfo(mCurrentInstance, path);
         if (!err.IsNone()) {
@@ -306,6 +306,11 @@ Error RootfsRuntime::CreateRuntimeInfo()
     }
 
     mRuntimeInfo.mMaxInstances = 1;
+
+    mDefaultInstanceIdent.mType      = UpdateItemTypeEnum::eComponent;
+    mDefaultInstanceIdent.mInstance  = 0;
+    mDefaultInstanceIdent.mItemID    = mRuntimeInfo.mRuntimeType;
+    mDefaultInstanceIdent.mSubjectID = nodeInfo->mNodeType;
 
     LOG_INF() << "Runtime info" << Log::Field("runtimeID", mRuntimeInfo.mRuntimeID)
               << Log::Field("runtimeType", mRuntimeInfo.mRuntimeType)
@@ -408,7 +413,7 @@ void RootfsRuntime::FillInstanceStatus(
     status.mRuntimeID                   = mRuntimeInfo.mRuntimeID;
     status.mManifestDigest              = instanceInfo.mManifestDigest;
     status.mType                        = UpdateItemTypeEnum::eComponent;
-    status.mPreinstalled                = status.mItemID.IsEmpty();
+    status.mPreinstalled                = static_cast<const InstanceIdent&>(instanceInfo) == mDefaultInstanceIdent;
 }
 
 Error RootfsRuntime::SaveInstanceInfo(const InstanceInfo& instance, const std::filesystem::path& path) const

--- a/src/sm/launcher/runtimes/rootfs/rootfs.hpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.hpp
@@ -174,6 +174,7 @@ private:
     InstanceStatusReceiverItf*             mStatusReceiver {};
     utils::SystemdUpdateChecker            mUpdateChecker;
     utils::SystemdRebooter                 mRebooter;
+    InstanceIdent                          mDefaultInstanceIdent;
 
     mutable std::mutex         mMutex;
     std::optional<std::thread> mHealthCheckThread;

--- a/src/sm/launcher/runtimes/rootfs/tests/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/tests/rootfs.cpp
@@ -128,7 +128,8 @@ protected:
         WriteFiles();
 
         EXPECT_CALL(mCurrentNodeInfoProvider, GetCurrentNodeInfo(_)).WillRepeatedly(Invoke([](NodeInfo& nodeInfo) {
-            nodeInfo.mNodeID = "nodeId";
+            nodeInfo.mNodeID   = "nodeId";
+            nodeInfo.mNodeType = "nodeType";
 
             return ErrorEnum::eNone;
         }));
@@ -282,7 +283,12 @@ TEST_F(RootfsRuntimeTest, StartPreinstalledInstance)
 
     err = mStatusReceiver.GetStatuses(onStartStatuses, std::chrono::seconds(1));
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
+
     ASSERT_EQ(onStartStatuses.size(), 1u);
+    EXPECT_EQ(onStartStatuses[0].mState, InstanceStateEnum::eActive);
+    EXPECT_STREQ(onStartStatuses[0].mItemID.CStr(), "rootfs");
+    EXPECT_STREQ(onStartStatuses[0].mSubjectID.CStr(), "nodeType");
+    EXPECT_STREQ(onStartStatuses[0].mVersion.CStr(), "1.0.0");
     EXPECT_TRUE(onStartStatuses[0].mPreinstalled);
 
     std::vector<InstanceStatus> onStartInstanceStatuses;


### PR DESCRIPTION
This patch updates preinstalled instance handling:
- set itemID to runtime type;
- set subjectID to current node type;
- set instance status preinstalled if matches default ident.