### PR TITLE
iam: iamclient: set empty cert storage in provision mode

### DIFF
--- a/src/common/iamclient/publicnodeservice.cpp
+++ b/src/common/iamclient/publicnodeservice.cpp
@@ -251,6 +251,8 @@ void PublicNodesService::ConnectionLoop()
 
         std::unique_lock lock {mMutex};
 
+        LOG_WRN() << "Connection failed" << Log::Field("retryingInSec", cReconnectInterval.count());
+
         mCV.wait_for(lock, cReconnectInterval, [this]() { return mStop.load(); });
     }
 

--- a/src/iam/iamclient/iamclient.cpp
+++ b/src/iam/iamclient/iamclient.cpp
@@ -28,7 +28,7 @@ Error IAMClient::Init(const config::IAMClientConfig& config, aos::iamclient::Ide
     mCurrentNodeHandler = &currentNodeHandler;
     mCertProvider       = &certProvider;
     mProvisionManager   = &provisionManager;
-    mCertStorage        = config.mCertStorage;
+    mCertStorage        = !provisioningMode ? config.mCertStorage : "";
 
     return PublicNodesService::Init(
         provisioningMode ? config.mMainIAMPublicServerURL : config.mMainIAMProtectedServerURL, tlsCredentials,

--- a/src/sm/smclient/smclient.cpp
+++ b/src/sm/smclient/smclient.cpp
@@ -683,7 +683,8 @@ void SMClient::ConnectionLoop() noexcept
     LOG_DBG() << "SM client connection thread started";
 
     while (true) {
-        LOG_DBG() << "Connecting to SM server...";
+        LOG_DBG() << "Connecting to SM server" << Log::Field("url", mConfig.mCMServerURL.c_str())
+                  << Log::Field("secure", mSecureConnection);
 
         if (RegisterSM(mConfig.mCMServerURL)) {
             if (!SendSMInfo()) {


### PR DESCRIPTION
In provision mode we use open connection e.g. we don't use any key/cert.