### PR TITLE
sm: launcher: container: do not set 0 error code as error

### DIFF
--- a/src/sm/launcher/runtimes/container/instance.cpp
+++ b/src/sm/launcher/runtimes/container/instance.cpp
@@ -128,7 +128,7 @@ Error Instance::Start()
     mRunStatus = mRunner.StartInstance(mInstanceID, itemConfig->mRunParameters);
     err        = mRunStatus.mError;
 
-    if (!err.IsNone()) {
+    if (mRunStatus.mState != InstanceStateEnum::eActive) {
         return AOS_ERROR_WRAP(err);
     }
 


### PR DESCRIPTION
Systemd conn may return error code 0 but instance is not started within start interval. In this case we set this instance as failed but returned error is none.