### PR TITLE
sm: config: add a dedicated config entry for resource config file

### DIFF
--- a/src/sm/app/aoscore.cpp
+++ b/src/sm/app/aoscore.cpp
@@ -59,7 +59,7 @@ void AosCore::Init(const std::string& configFile)
 
     // Initialize resource manager
 
-    err = mResourceManager.Init({mConfig.mNodeConfigFile.c_str()});
+    err = mResourceManager.Init({mConfig.mResourcesConfigFile.c_str()});
     AOS_ERROR_CHECK_AND_THROW(err, "can't initialize resource manager");
 
     // Initialize database

--- a/src/sm/config/config.cpp
+++ b/src/sm/config/config.cpp
@@ -28,6 +28,7 @@ constexpr auto cDefaultRemoveOutdatedPeriod = "24h";
 constexpr auto cDefaultHealthCheckTimeout   = "35s";
 constexpr auto cDefaultCMReconnectTimeout   = "10s";
 const auto     cEmptyObject                 = Poco::makeShared<Poco::JSON::Object>();
+constexpr auto cResourceConfigFileName      = "/etc/aos/resources.cfg";
 
 namespace aos::sm::config {
 
@@ -121,6 +122,9 @@ Error ParseConfig(const std::string& filename, Config& config)
 
         config.mNodeConfigFile = object.GetOptionalValue<std::string>("nodeConfigFile")
                                      .value_or(common::utils::JoinPath(config.mWorkingDir, "aos_node.cfg"));
+
+        config.mResourcesConfigFile
+            = object.GetOptionalValue<std::string>("resourcesConfigFile").value_or(cResourceConfigFileName);
 
         auto empty = common::utils::CaseInsensitiveObjectWrapper(Poco::makeShared<Poco::JSON::Object>());
 

--- a/src/sm/config/config.hpp
+++ b/src/sm/config/config.hpp
@@ -36,6 +36,7 @@ struct Config {
     std::string                   mCertStorage;
     std::string                   mIAMProtectedServerURL;
     std::string                   mNodeConfigFile;
+    std::string                   mResourcesConfigFile;
     std::string                   mWorkingDir;
     common::config::JournalAlerts mJournalAlerts;
     common::config::Migration     mMigration;

--- a/src/sm/config/tests/config.cpp
+++ b/src/sm/config/tests/config.cpp
@@ -76,6 +76,7 @@ static constexpr auto cTestServiceManagerJSON          = R"({
         "pollPeriod": "1h1m5s"
     },
     "nodeConfigFile": "/var/aos/aos_node.cfg",
+    "resourcesConfigFile": "/var/aos/resources.cfg",
     "workingDir": "workingDir"
 })";
 static constexpr auto cTestDefaultValuesJSON           = R"({
@@ -192,6 +193,7 @@ TEST_F(ConfigTest, ParseConfig)
     EXPECT_EQ(config->mMonitoring.mPollPeriod, aos::Time::cHours + aos::Time::cMinutes + 5 * aos::Time::cSeconds);
 
     EXPECT_EQ(config->mNodeConfigFile, "/var/aos/aos_node.cfg");
+    EXPECT_EQ(config->mResourcesConfigFile, "/var/aos/resources.cfg");
     EXPECT_EQ(config->mWorkingDir, "workingDir");
 }
 
@@ -218,6 +220,7 @@ TEST_F(ConfigTest, DefaultValuesAreUsed)
     ASSERT_EQ(config->mWorkingDir, "test");
 
     EXPECT_EQ(config->mNodeConfigFile, "test/aos_node.cfg");
+    EXPECT_EQ(config->mResourcesConfigFile, "/etc/aos/resources.cfg");
 }
 
 TEST_F(ConfigTest, ErrorReturnedOnFileMissing)


### PR DESCRIPTION
This patch adds a new entry to the main config for resource config. Node config and resource config are different entities, so they should be configured separately.