### PR TITLE
cm: fix application crash on cert handler CreateKey call

### DIFF
--- a/src/cm/communication/communication.cpp
+++ b/src/cm/communication/communication.cpp
@@ -1264,7 +1264,7 @@ void Communication::HandleMessage(const ResponseInfo& info, const RenewCertsNoti
         }
 
         if (auto err = mCertHandler->CreateKey(
-                cert.mNodeID, cert.mType.ToString(), {}, itSecrets->mSecret, newCerts->mRequests.Back().mCSR);
+                cert.mNodeID, cert.mType.ToString(), "", itSecrets->mSecret, newCerts->mRequests.Back().mCSR);
             !err.IsNone()) {
             LOG_ERR() << "Create key failed" << Log::Field(err);
             return;


### PR DESCRIPTION
String default constructor initializes internal buffer with nullptr, causing a crash in CreateKey when the param is converted to std::string via CStr call.
Initialize with an empty string literal instead to ensure the internal buffer points to valid memory.