### PR TITLE
common: cloudprotocol: fix parsing of blockKey and blockIv

### DIFF
--- a/src/common/cloudprotocol/blobs.cpp
+++ b/src/common/cloudprotocol/blobs.cpp
@@ -25,11 +25,11 @@ void DecryptInfoFromJSON(const common::utils::CaseInsensitiveObjectWrapper& json
     AOS_ERROR_CHECK_AND_THROW(err, "can't parse blockAlg");
 
     const auto iv = common::utils::Base64Decode(json.GetValue<std::string>("blockIv"));
-    err           = decryptInfo.mBlockIV.Assign(String(iv.c_str()).AsByteArray());
+    err           = decryptInfo.mBlockIV.Assign(String(iv.data(), iv.size()).AsByteArray());
     AOS_ERROR_CHECK_AND_THROW(err, "can't parse blockIv");
 
     const auto key = common::utils::Base64Decode(json.GetValue<std::string>("blockKey"));
-    err            = decryptInfo.mBlockKey.Assign(String(key.c_str()).AsByteArray());
+    err            = decryptInfo.mBlockKey.Assign(String(key.data(), key.size()).AsByteArray());
     AOS_ERROR_CHECK_AND_THROW(err, "can't parse blockKey");
 }
 

--- a/src/common/cloudprotocol/tests/blobs.cpp
+++ b/src/common/cloudprotocol/tests/blobs.cpp
@@ -72,8 +72,8 @@ TEST_F(CloudProtocolBlobs, BlobURLsInfo)
                 "size": 1000,
                 "decryptInfo": {
                     "blockAlg": "AES256/CBC/pkcs7",
-                    "blockIv": "YmxvY2tJdg==",
-                    "blockKey": "YmxvY2tLZXk="
+                    "blockIv": "MTYgYnl0ZXMgaXYgIHN0cg==",
+                    "blockKey": "MTYgYnl0ZXMga2V5IHN0cg=="
                 },
                 "signInfo": {
                     "chainName": "chainName",
@@ -117,8 +117,11 @@ TEST_F(CloudProtocolBlobs, BlobURLsInfo)
 
     ASSERT_TRUE(image.mDecryptInfo.HasValue());
     EXPECT_STREQ(image.mDecryptInfo->mBlockAlg.CStr(), "AES256/CBC/pkcs7");
-    EXPECT_EQ(image.mDecryptInfo->mBlockIV, String("blockIv").AsByteArray());
-    EXPECT_EQ(image.mDecryptInfo->mBlockKey, String("blockKey").AsByteArray());
+    EXPECT_EQ(image.mDecryptInfo->mBlockIV.Size(), 16);
+    EXPECT_EQ(image.mDecryptInfo->mBlockIV, String("16 bytes iv  str").AsByteArray());
+
+    EXPECT_EQ(image.mDecryptInfo->mBlockKey, String("16 bytes key str").AsByteArray());
+    EXPECT_EQ(image.mDecryptInfo->mBlockKey.Size(), 16);
 
     ASSERT_TRUE(image.mSignInfo.HasValue());
     EXPECT_STREQ(image.mSignInfo->mChainName.CStr(), "chainName");


### PR DESCRIPTION
Create a string object using the data and size
to avoid parsing errors when data contains null bytes.