### PR TITLE
sm: logprovider: pass log sender in the init method

### DIFF
--- a/src/sm/app/aoscore.cpp
+++ b/src/sm/app/aoscore.cpp
@@ -152,7 +152,7 @@ void AosCore::Init(const std::string& configFile)
 
     // Initialize logprovider
 
-    err = mLogProvider.Init(mConfig.mLogging, *containerRuntime);
+    err = mLogProvider.Init(mConfig.mLogging, *containerRuntime, mSMClient);
     AOS_ERROR_CHECK_AND_THROW(err, "can't initialize logprovider");
 
     // Initialize SM client

--- a/src/sm/logprovider/logprovider.cpp
+++ b/src/sm/logprovider/logprovider.cpp
@@ -22,12 +22,14 @@ namespace aos::sm::logprovider {
  * Public
  **********************************************************************************************************************/
 
-Error LogProvider::Init(const aos::logging::Config& config, InstanceIDProviderItf& instanceProvider)
+Error LogProvider::Init(
+    const aos::logging::Config& config, InstanceIDProviderItf& instanceProvider, aos::logging::SenderItf& logSender)
 {
     LOG_DBG() << "Init log provider";
 
     mConfig           = config;
     mInstanceProvider = &instanceProvider;
+    mLogSender        = &logSender;
 
     return ErrorEnum::eNone;
 }
@@ -124,26 +126,6 @@ Error LogProvider::GetSystemLog(const RequestLog& request)
     LOG_DBG() << "Get system log: correlationId=" << request.mCorrelationID;
 
     ScheduleGetLog({}, request.mCorrelationID, request.mFilter.mFrom, request.mFilter.mTill);
-
-    return ErrorEnum::eNone;
-}
-
-Error LogProvider::Subscribe(aos::logging::SenderItf& sender)
-{
-    std::unique_lock<std::mutex> lock {mMutex};
-
-    mLogSender = &sender;
-
-    return ErrorEnum::eNone;
-}
-
-Error LogProvider::Unsubscribe(const aos::logging::SenderItf& sender)
-{
-    (void)sender;
-
-    std::unique_lock<std::mutex> lock {mMutex};
-
-    mLogSender = nullptr;
 
     return ErrorEnum::eNone;
 }

--- a/src/sm/logprovider/logprovider.hpp
+++ b/src/sm/logprovider/logprovider.hpp
@@ -33,9 +33,11 @@ public:
      * @param instanceProvider instance provider.
      * @param logReceiver log receiver.
      * @param config log provider config.
+     * @param logSender log sender.
      * @return Error.
      */
-    Error Init(const aos::logging::Config& config, InstanceIDProviderItf& instanceProvider);
+    Error Init(const aos::logging::Config& config, InstanceIDProviderItf& instanceProvider,
+        aos::logging::SenderItf& logSender);
 
     /**
      * Starts requests processing thread.
@@ -79,22 +81,6 @@ public:
      * @return bool.
      */
     Error GetSystemLog(const RequestLog& request) override;
-
-    /**
-     * Subscribes on logs.
-     *
-     * @param sender log sender.
-     * @return Error.
-     */
-    Error Subscribe(aos::logging::SenderItf& sender);
-
-    /**
-     * Unsubscribes from logs.
-     *
-     * @param sender log sender.
-     * @return Error.
-     */
-    Error Unsubscribe(const aos::logging::SenderItf& sender);
 
 private:
     static constexpr auto cAOSServicePrefix = "aos-service@";

--- a/src/sm/logprovider/tests/logprovider.cpp
+++ b/src/sm/logprovider/tests/logprovider.cpp
@@ -44,8 +44,7 @@ public:
 
         auto config = aos::logging::Config {200, 10};
 
-        mLogProvider.Init(config, mInstanceIDProvider);
-        mLogProvider.Subscribe(mLogSender);
+        mLogProvider.Init(config, mInstanceIDProvider, mLogSender);
         mLogProvider.Start();
     }
 


### PR DESCRIPTION
This patch fixes an issue with log provider initialization: accept log sender in the init method instead of subscribe method.