### PR TITLE
cm: networkmanager: fix early return in RemoveInstanceNetworkParameters

### DIFF
--- a/src/cm/networkmanager/networkmanager.cpp
+++ b/src/cm/networkmanager/networkmanager.cpp
@@ -109,10 +109,11 @@ Error NetworkManager::RemoveInstanceNetworkParameters(const InstanceIdent& insta
 
             auto itInstance = itHost->second.mInstances.find(instanceIdent);
             if (itInstance == itHost->second.mInstances.end()) {
-                LOG_WRN() << "Instance network parameters not found" << Log::Field("instanceIdent", instanceIdent)
-                          << Log::Field("nodeID", nodeID);
+                LOG_DBG() << "Instance network parameters not found in network"
+                          << Log::Field("instanceIdent", instanceIdent)
+                          << Log::Field("networkID", networkID.c_str()) << Log::Field("nodeID", nodeID);
 
-                return ErrorEnum::eNone;
+                continue;
             }
 
             RemoveInstanceNetwork(networkID, itInstance->second.mIP.CStr(), instanceIdent);


### PR DESCRIPTION
Replace `return eNone` with `continue` when instance is not found in a network's host instances. The early return prevented searching other networks, leaving the instance in memory for the old node. During provider network cleanup the same instance was deleted from DB twice: first deletion succeeded, second got eNotFound and threw an error.