### PR TITLE
cm: networkmanager: cleanup instance state on prepare failure

### DIFF
--- a/src/cm/networkmanager/networkmanager.cpp
+++ b/src/cm/networkmanager/networkmanager.cpp
@@ -228,19 +228,29 @@ Error NetworkManager::PrepareInstanceNetworkParameters(const InstanceIdent& inst
             return err;
         }
 
-        itHost->second.mInstances.emplace(instanceIdent, instance);
+        auto [itInstance2, _] = itHost->second.mInstances.emplace(instanceIdent, instance);
 
-        if (auto err = PrepareFirewallRules(
+        Error err;
+
+        auto cleanupInstance = DeferRelease(&err, [this, &itHost, &itInstance2, &networkID, &IP](const Error* err) {
+            if (!err->IsNone()) {
+                itHost->second.mInstances.erase(itInstance2);
+                mHosts.erase(IP);
+                mIpSubnet.ReleaseIPToSubnet(networkID.CStr(), IP);
+            }
+        });
+
+        if (err = PrepareFirewallRules(
                 it->second.mNetwork.mSubnet.CStr(), IP.c_str(), networkData.mAllowedConnections, result);
             !err.IsNone()) {
             return err;
         }
 
-        if (auto err = AddHosts(hosts, IP); !err.IsNone()) {
+        if (err = AddHosts(hosts, IP); !err.IsNone()) {
             return err;
         }
 
-        if (auto err = mStorage->AddInstance(instance); !err.IsNone()) {
+        if (err = mStorage->AddInstance(instance); !err.IsNone()) {
             return AOS_ERROR_WRAP(err);
         }
 
@@ -382,11 +392,11 @@ Error NetworkManager::PrepareFirewallRules(const std::string& subnet, const Stri
 
 Error NetworkManager::AddHosts(const std::vector<std::string>& hosts, const std::string& ip)
 {
-    for (const auto& host : hosts) {
-        if (IsHostExist(host)) {
-            return Error(ErrorEnum::eAlreadyExist, "host already exists");
-        }
+    if (std::any_of(hosts.begin(), hosts.end(), [this](const auto& host) { return IsHostExist(host); })) {
+        return Error(ErrorEnum::eAlreadyExist, "host already exists");
+    }
 
+    for (const auto& host : hosts) {
         mHosts[ip].push_back(host);
     }
 


### PR DESCRIPTION
When PrepareInstanceNetworkParameters fails after emplacing an instance into the in-memory map (e.g. due to duplicate hosts), the instance, hosts and allocated IP were left in an inconsistent state. This caused "host already exists" errors on subsequent install attempts and "error removing instance" on deletion.

Fix by adding DeferRelease to rollback mInstances, mHosts and IP allocation on failure. Also make AddHosts atomic by validating all hosts before adding any.