### PR TITLE
sm: launcher: runtimes: rootfs: copy image instead of unpacking

### DIFF
--- a/src/sm/launcher/runtimes/rootfs/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.cpp
@@ -220,7 +220,7 @@ void RootfsRuntime::RunHealthCheck(std::unique_ptr<InstanceStatus> status)
         status->mError = AOS_ERROR_WRAP(err);
     }
 
-    if (auto err = mRebooter.Reboot(); !err.IsNone()) {
+    if (auto err = mStatusReceiver->RebootRequired(mRuntimeInfo.mRuntimeID); !err.IsNone()) {
         status->mState = InstanceStateEnum::eFailed;
         status->mError = AOS_ERROR_WRAP(err);
     }

--- a/src/sm/launcher/runtimes/rootfs/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.cpp
@@ -628,6 +628,8 @@ Error RootfsRuntime::PrepareUpdate(const InstanceInfo& instance)
         return AOS_ERROR_WRAP(err);
     }
 
+    mPendingInstance = instance;
+
     return ErrorEnum::eNone;
 }
 

--- a/src/sm/launcher/runtimes/rootfs/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.cpp
@@ -502,7 +502,7 @@ Error RootfsRuntime::GetImageManifest(const String& digest, oci::ImageManifest& 
     return ErrorEnum::eNone;
 }
 
-Error RootfsRuntime::UnpackImage(const oci::ImageManifest& manifest) const
+Error RootfsRuntime::CopyImage(const oci::ImageManifest& manifest) const
 {
     if (manifest.mLayers.Size() == 0) {
         return AOS_ERROR_WRAP(Error(ErrorEnum::eInvalidArgument, "image manifest has no layers"));
@@ -517,11 +517,13 @@ Error RootfsRuntime::UnpackImage(const oci::ImageManifest& manifest) const
     LOG_DBG() << "Unpack image layer" << Log::Field("digest", manifest.mLayers[0].mDigest)
               << Log::Field("path", imageArchivePath.CStr());
 
-    const std::vector<std::string> cmdArgs {"tar", "xzf", imageArchivePath.CStr(), "-C", mRootfsConfig.mWorkingDir};
+    std::error_code ec;
 
-    auto [_, err] = common::utils::ExecCommand(cmdArgs);
-    if (!err.IsNone()) {
-        return AOS_ERROR_WRAP(err);
+    std::filesystem::copy_file(imageArchivePath.CStr(), GetPath("image.squashfs").c_str(),
+        std::filesystem::copy_options::overwrite_existing, ec);
+
+    if (ec.value() != 0) {
+        return AOS_ERROR_WRAP(Error(ec.value(), ec.message().c_str()));
     }
 
     return ErrorEnum::eNone;
@@ -608,7 +610,7 @@ Error RootfsRuntime::PrepareUpdate(const InstanceInfo& instance)
         return AOS_ERROR_WRAP(err);
     }
 
-    if (auto err = UnpackImage(*imageManifest); !err.IsNone()) {
+    if (auto err = CopyImage(*imageManifest); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 

--- a/src/sm/launcher/runtimes/rootfs/rootfs.cpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.cpp
@@ -435,6 +435,7 @@ Error RootfsRuntime::SaveInstanceInfo(const InstanceInfo& instance, const std::f
     try {
         json->set("itemId", instance.mItemID.CStr());
         json->set("subjectId", instance.mSubjectID.CStr());
+        json->set("instance", instance.mInstance);
         json->set("manifestDigest", instance.mManifestDigest.CStr());
         json->set("type", instance.mType.ToString().CStr());
         json->set("version", instance.mVersion.CStr());
@@ -471,6 +472,8 @@ Error RootfsRuntime::LoadInstanceInfo(const std::filesystem::path& path, Instanc
 
         err = instance.mSubjectID.Assign(jsonObject.GetValue<std::string>("subjectId").c_str());
         AOS_ERROR_CHECK_AND_THROW(err);
+
+        instance.mInstance = jsonObject.GetValue<uint64_t>("instance");
 
         err = instance.mManifestDigest.Assign(jsonObject.GetValue<std::string>("manifestDigest").c_str());
         AOS_ERROR_CHECK_AND_THROW(err);

--- a/src/sm/launcher/runtimes/rootfs/rootfs.hpp
+++ b/src/sm/launcher/runtimes/rootfs/rootfs.hpp
@@ -159,7 +159,7 @@ private:
     Error SaveInstanceInfo(const InstanceInfo& instance, const std::filesystem::path& path) const;
     Error LoadInstanceInfo(const std::filesystem::path& path, InstanceInfo& instance);
     Error GetImageManifest(const String& digest, oci::ImageManifest& manifest) const;
-    Error UnpackImage(const oci::ImageManifest& manifest) const;
+    Error CopyImage(const oci::ImageManifest& manifest) const;
     Error PrepareUpdateFileContent(const oci::ImageManifest& manifest, std::string& updateType) const;
     void  ClearUpdateArtifacts() const;
     Error StoreAction(const ActionType& action, const std::string& data = "") const;


### PR DESCRIPTION
The rootfs update image is already unpacked, so just copy it to the target location.