### PR TITLE
cm: handle provisioning

### DIFF
--- a/src/cm/communication/communication.cpp
+++ b/src/cm/communication/communication.cpp
@@ -12,6 +12,7 @@
 #include <Poco/Net/SSLManager.h>
 
 #include <core/common/tools/logger.hpp>
+#include <core/iam/provisionmanager/itf/provisionmanager.hpp>
 
 #include <common/cloudprotocol/alerts.hpp>
 #include <common/cloudprotocol/blobs.hpp>
@@ -1219,8 +1220,60 @@ void Communication::HandleMessage(const ResponseInfo& info, const StartProvision
         LOG_ERR() << "Send ack failed" << Log::Field("txn", info.mTxn.c_str()) << Log::Field(err);
     }
 
+    auto response = std::make_unique<StartProvisioningResponse>();
+
+    if (auto err = response->mCorrelationID.Assign(info.mCorrelationID.c_str()); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign correlation ID to response" << Log::Field(err);
+
+        return;
+    }
+
+    if (auto err = response->mNodeID.Assign(request.mNodeID); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign node ID to response" << Log::Field(err);
+
+        return;
+    }
+
+    auto sendResponse = DeferRelease(response.get(), [this, &info](StartProvisioningResponse* response) {
+        if (auto err = SendProvisioningResponse(info.mCorrelationID, CreateMessageData(*response)); !err.IsNone()) {
+            LOG_ERR() << "Send start provisioning failed" << Log::Field(err);
+        }
+    });
+
     if (auto err = mProvisioningHandler->StartProvisioning(request.mNodeID, request.mPassword); !err.IsNone()) {
-        LOG_ERR() << "Start provisioning failed" << Log::Field(err);
+        response->mError = AOS_ERROR_WRAP(err);
+
+        return;
+    }
+
+    auto nodeCertTypes = std::make_unique<iam::provisionmanager::CertTypes>();
+
+    if (auto err = mProvisioningHandler->GetCertTypes(request.mNodeID, *nodeCertTypes); !err.IsNone()) {
+        response->mError = AOS_ERROR_WRAP(err);
+
+        return;
+    }
+
+    for (const auto& cert : *nodeCertTypes) {
+        if (auto err = response->mCSRs.EmplaceBack(); !err.IsNone()) {
+            response->mError = AOS_ERROR_WRAP(err);
+
+            return;
+        }
+
+        if (auto err = response->mCSRs.Back().mType.FromString(cert); !err.IsNone()) {
+            response->mError = AOS_ERROR_WRAP(err);
+
+            return;
+        }
+
+        if (auto err
+            = mCertHandler->CreateKey(request.mNodeID, cert, "", request.mPassword.CStr(), response->mCSRs.Back().mCSR);
+            !err.IsNone()) {
+            response->mError = AOS_ERROR_WRAP(err);
+
+            return;
+        }
     }
 }
 
@@ -1233,8 +1286,41 @@ void Communication::HandleMessage(const ResponseInfo& info, const FinishProvisio
         LOG_ERR() << "Send ack failed" << Log::Field("txn", info.mTxn.c_str()) << Log::Field(err);
     }
 
+    auto response = std::make_unique<FinishProvisioningResponse>();
+
+    if (auto err = response->mCorrelationID.Assign(info.mCorrelationID.c_str()); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign correlation ID to response" << Log::Field(err);
+
+        return;
+    }
+
+    if (auto err = response->mNodeID.Assign(request.mNodeID); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign node ID to response" << Log::Field(err);
+
+        return;
+    }
+
+    auto sendResponse = DeferRelease(response.get(), [this, &info](FinishProvisioningResponse* response) {
+        if (auto err = SendProvisioningResponse(info.mCorrelationID, CreateMessageData(*response)); !err.IsNone()) {
+            LOG_ERR() << "Send finish provisioning failed" << Log::Field(err);
+        }
+    });
+
+    for (const auto& cert : request.mCertificates) {
+        auto certInfo = std::make_unique<CertInfo>();
+
+        if (auto err = mCertHandler->ApplyCert(request.mNodeID, cert.mCertType.ToString(), cert.mCertChain, *certInfo);
+            !err.IsNone()) {
+            response->mError = AOS_ERROR_WRAP(err);
+
+            return;
+        }
+    }
+
     if (auto err = mProvisioningHandler->FinishProvisioning(request.mNodeID, request.mPassword); !err.IsNone()) {
-        LOG_ERR() << "Finish provisioning failed" << Log::Field(err);
+        response->mError = AOS_ERROR_WRAP(err);
+
+        return;
     }
 }
 
@@ -1247,8 +1333,26 @@ void Communication::HandleMessage(const ResponseInfo& info, const Deprovisioning
         LOG_ERR() << "Send ack failed" << Log::Field("txn", info.mTxn.c_str()) << Log::Field(err);
     }
 
+    auto response = std::make_unique<DeprovisioningResponse>();
+
+    if (auto err = response->mCorrelationID.Assign(info.mCorrelationID.c_str()); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign correlation ID to response" << Log::Field(err);
+
+        return;
+    }
+
+    if (auto err = response->mNodeID.Assign(request.mNodeID); !err.IsNone()) {
+        LOG_ERR() << "Failed to assign node ID to response" << Log::Field(err);
+
+        return;
+    }
+
     if (auto err = mProvisioningHandler->Deprovision(request.mNodeID, request.mPassword); !err.IsNone()) {
-        LOG_ERR() << "Deprovisioning failed" << Log::Field(err);
+        response->mError = AOS_ERROR_WRAP(err);
+    }
+
+    if (auto err = SendProvisioningResponse(info.mCorrelationID, CreateMessageData(*response)); !err.IsNone()) {
+        LOG_ERR() << "Send deprovisioning response failed" << Log::Field(err);
     }
 }
 
@@ -1443,6 +1547,21 @@ Error Communication::SendInstallUnitCertsConfirmation(const InstallUnitCertsConf
 
     try {
         if (auto err = EnqueueMessage(CreateMessageData(confirmation), true); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+    } catch (const std::exception& e) {
+        return common::utils::ToAosError(e);
+    }
+
+    return ErrorEnum::eNone;
+}
+
+Error Communication::SendProvisioningResponse(const std::string& correlationId, Poco::JSON::Object::Ptr response)
+{
+    LOG_DBG() << "Send provisioning response" << Log::Field("correlationId", correlationId.c_str());
+
+    try {
+        if (auto err = EnqueueMessage(response); !err.IsNone()) {
             return AOS_ERROR_WRAP(err);
         }
     } catch (const std::exception& e) {

--- a/src/cm/communication/communication.hpp
+++ b/src/cm/communication/communication.hpp
@@ -283,6 +283,7 @@ private:
     Error SendAck(const std::string& correlationId);
     Error SendIssueUnitCerts(const IssueUnitCerts& certs);
     Error SendInstallUnitCertsConfirmation(const InstallUnitCertsConfirmation& confirmation);
+    Error SendProvisioningResponse(const std::string& correlationId, Poco::JSON::Object::Ptr response);
     void  OnResponseReceived(const ResponseInfo& info, ResponseMessageVariantPtr message);
     void  WriteToMessageLog(const std::string& direction, const std::string& message);
 

--- a/src/cm/communication/tests/communication.cpp
+++ b/src/cm/communication/tests/communication.cpp
@@ -498,6 +498,196 @@ TEST_F(CMCommunicationTest, SendOverrideEnvsStatuses)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 }
 
+TEST_F(CMCommunicationTest, HandleStartProvisioning)
+{
+    constexpr auto cMessage                           = R"({
+        "header": {
+            "version": 7,
+            "systemId": "test_system_id",
+            "createdAt": "2026-05-07T05:44:11.061622Z",
+            "txn": "txnUD"
+        },
+        "data": {
+            "correlationId": "2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",
+            "messageType": "startProvisioningRequest",
+            "node": {
+                "type": "node",
+                "codename": "nodeID"
+            },
+            "password": "Passw0rd!"
+        }
+    })";
+    const auto     cExpectedStartProvisioningResponse = std::regex(
+        R"(^\{"header":\{"version":7,"systemId":"test_system_id","createdAt":"[^"]+",)"
+            R"("txn":"fb6e8461-2601-4f9a-8957-7ab4e52f304c"\},)"
+            R"("data":\{"messageType":"startProvisioningResponse","correlationId":"2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",)"
+            R"("node":\{"codename":"nodeID"\},"csrs":\[\{"type":"cm","csr":"cm"\},\{"type":"iam","csr":"iam"\}\]\}\}$)");
+
+    SubscribeAndWaitConnected();
+
+    mUUIDProvider.SetUUID("fb6e8461-2601-4f9a-8957-7ab4e52f304c");
+
+    std::promise<void> messageHandled;
+
+    EXPECT_CALL(mProvisioningMock, StartProvisioning)
+        .WillOnce(Invoke([&messageHandled](const auto& nodeID, const auto& password) {
+            EXPECT_STREQ(nodeID.CStr(), "nodeID");
+            EXPECT_STREQ(password.CStr(), "Passw0rd!");
+
+            messageHandled.set_value();
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mProvisioningMock, GetCertTypes).WillOnce(Invoke([](const auto& nodeID, auto& certTypes) {
+        EXPECT_STREQ(nodeID.CStr(), "nodeID");
+
+        certTypes.EmplaceBack("cm");
+        certTypes.EmplaceBack("iam");
+        return ErrorEnum::eNone;
+    }));
+
+    for (const auto& certType : {"cm", "iam"}) {
+        EXPECT_CALL(mCertHandlerMock, CreateKey(String("nodeID"), String(certType), _, String("Passw0rd!"), _))
+            .WillOnce(DoAll(SetArgReferee<4>(String {certType}), Return(ErrorEnum::eNone)));
+    }
+
+    mCloudSendMessageQueue.Push(cMessage);
+
+    EXPECT_EQ(messageHandled.get_future().wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    EXPECT_TRUE(mCloudReceivedMessages.Pop().has_value()) << "Ack message expected, but not received";
+
+    const auto cReceivedStartProvisioningResponse = mCloudReceivedMessages.Pop().value_or("");
+    EXPECT_TRUE(std::regex_match(cReceivedStartProvisioningResponse, cExpectedStartProvisioningResponse))
+        << "Received message: " << cReceivedStartProvisioningResponse;
+
+    auto err = mCommunication.Stop();
+    ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
+}
+
+TEST_F(CMCommunicationTest, HandleFinishProvisioning)
+{
+    constexpr auto cMessage                            = R"({
+        "header": {
+            "version": 7,
+            "systemId": "test_system_id",
+            "createdAt": "2026-05-07T05:44:11.061622Z",
+            "txn": "txnUD"
+        },
+        "data": {
+            "correlationId": "2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",
+            "messageType": "finishProvisioningRequest",
+            "node": {
+                "type": "node",
+                "codename": "nodeID"
+            },
+            "certificates": [
+                {
+                    "type": "iam",
+                    "chain": "iamChain"
+                },
+                {
+                    "type": "sm",
+                    "chain": "smChain"
+                }
+            ],
+            "password": "Passw0rd!"
+        }
+    })";
+    const auto     cExpectedFinishProvisioningResponse = std::regex(
+        R"(^\{"header":\{"version":7,"systemId":"test_system_id","createdAt":"[^"]+",)"
+            R"("txn":"fb6e8461-2601-4f9a-8957-7ab4e52f304c"\},)"
+            R"("data":\{"messageType":"finishProvisioningResponse","correlationId":"2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",)"
+            R"("node":\{"codename":"nodeID"\}\}\}$)");
+
+    SubscribeAndWaitConnected();
+
+    mUUIDProvider.SetUUID("fb6e8461-2601-4f9a-8957-7ab4e52f304c");
+
+    std::promise<void> messageHandled;
+
+    EXPECT_CALL(mProvisioningMock, FinishProvisioning)
+        .WillOnce(Invoke([&messageHandled](const auto& nodeID, const auto& password) {
+            EXPECT_STREQ(nodeID.CStr(), "nodeID");
+            EXPECT_STREQ(password.CStr(), "Passw0rd!");
+
+            messageHandled.set_value();
+            return ErrorEnum::eNone;
+        }));
+
+    for (const auto& certType : {"sm", "iam"}) {
+        EXPECT_CALL(mCertHandlerMock, ApplyCert(String("nodeID"), String(certType), _, _))
+            .WillOnce(Return(ErrorEnum::eNone));
+    }
+
+    mCloudSendMessageQueue.Push(cMessage);
+
+    EXPECT_EQ(messageHandled.get_future().wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    EXPECT_TRUE(mCloudReceivedMessages.Pop().has_value()) << "Ack message expected, but not received";
+
+    const auto cReceivedFinishProvisioningResponse = mCloudReceivedMessages.Pop().value_or("");
+    EXPECT_TRUE(std::regex_match(cReceivedFinishProvisioningResponse, cExpectedFinishProvisioningResponse))
+        << "Received message: " << cReceivedFinishProvisioningResponse;
+
+    auto err = mCommunication.Stop();
+    ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
+}
+
+TEST_F(CMCommunicationTest, HandleDeprovisioning)
+{
+    constexpr auto cMessage                        = R"({
+        "header": {
+            "version": 7,
+            "systemId": "test_system_id",
+            "createdAt": "2026-05-07T05:44:11.061622Z",
+            "txn": "txnUD"
+        },
+        "data": {
+            "correlationId": "2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",
+            "messageType": "deprovisioningRequest",
+            "node": {
+                "type": "node",
+                "codename": "nodeID"
+            },
+            "password": "Passw0rd!"
+        }
+    })";
+    const auto     cExpectedDeprovisioningResponse = std::regex(
+        R"(^\{"header":\{"version":7,"systemId":"test_system_id","createdAt":"[^"]+",)"
+            R"("txn":"fb6e8461-2601-4f9a-8957-7ab4e52f304c"\},)"
+            R"("data":\{"messageType":"deprovisioningResponse","correlationId":"2a05b9cc-32fb-41b6-a099-0fca3bb39ce2",)"
+            R"("node":\{"codename":"nodeID"\}\}\}$)");
+
+    SubscribeAndWaitConnected();
+
+    mUUIDProvider.SetUUID("fb6e8461-2601-4f9a-8957-7ab4e52f304c");
+
+    std::promise<void> messageHandled;
+
+    EXPECT_CALL(mProvisioningMock, Deprovision)
+        .WillOnce(Invoke([&messageHandled](const auto& nodeID, const auto& password) {
+            EXPECT_STREQ(nodeID.CStr(), "nodeID");
+            EXPECT_STREQ(password.CStr(), "Passw0rd!");
+
+            messageHandled.set_value();
+            return ErrorEnum::eNone;
+        }));
+
+    mCloudSendMessageQueue.Push(cMessage);
+
+    EXPECT_EQ(messageHandled.get_future().wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    EXPECT_TRUE(mCloudReceivedMessages.Pop().has_value()) << "Ack message expected, but not received";
+
+    const auto cReceivedDeprovisioningResponse = mCloudReceivedMessages.Pop().value_or("");
+    EXPECT_TRUE(std::regex_match(cReceivedDeprovisioningResponse, cExpectedDeprovisioningResponse))
+        << "Received message: " << cReceivedDeprovisioningResponse;
+
+    auto err = mCommunication.Stop();
+    ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
+}
+
 TEST_F(CMCommunicationTest, GetBlobsInfosTimeout)
 {
     mConfig.mCloudResponseWaitTimeout = Time::cMilliseconds;

--- a/src/common/iamclient/provisioningservice.cpp
+++ b/src/common/iamclient/provisioningservice.cpp
@@ -107,7 +107,7 @@ Error ProvisioningService::StartProvisioning(const String& nodeID, const String&
 
     try {
         auto ctx = std::make_unique<grpc::ClientContext>();
-        ctx->set_deadline(std::chrono::system_clock::now() + cServiceTimeout);
+        ctx->set_deadline(std::chrono::system_clock::now() + cProvisioningTimeout);
 
         iamanager::v6::StartProvisioningRequest  request;
         iamanager::v6::StartProvisioningResponse response;
@@ -137,7 +137,7 @@ Error ProvisioningService::FinishProvisioning(const String& nodeID, const String
 
     try {
         auto ctx = std::make_unique<grpc::ClientContext>();
-        ctx->set_deadline(std::chrono::system_clock::now() + cServiceTimeout);
+        ctx->set_deadline(std::chrono::system_clock::now() + cProvisioningTimeout);
 
         iamanager::v6::FinishProvisioningRequest  request;
         iamanager::v6::FinishProvisioningResponse response;
@@ -167,7 +167,7 @@ Error ProvisioningService::Deprovision(const String& nodeID, const String& passw
 
     try {
         auto ctx = std::make_unique<grpc::ClientContext>();
-        ctx->set_deadline(std::chrono::system_clock::now() + cServiceTimeout);
+        ctx->set_deadline(std::chrono::system_clock::now() + cProvisioningTimeout);
 
         iamanager::v6::DeprovisionRequest  request;
         iamanager::v6::DeprovisionResponse response;

--- a/src/common/iamclient/provisioningservice.hpp
+++ b/src/common/iamclient/provisioningservice.hpp
@@ -79,7 +79,8 @@ public:
     Error Reconnect();
 
 private:
-    static constexpr auto cServiceTimeout = std::chrono::seconds(10);
+    static constexpr auto cServiceTimeout      = std::chrono::seconds(10);
+    static constexpr auto cProvisioningTimeout = std::chrono::minutes(10);
 
     std::string                                                  mIAMProtectedServerURL;
     std::string                                                  mCertStorage;


### PR DESCRIPTION
Both plain and TLS credentials should be created for a secondary node in a provisioning node.