### PR TITLE
doc: README: add clone step and missing build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,29 @@
 
 # AosCore C++ implementation
 
-## Prepare build environment
+## Get the sources
 
 ```console
-sudo apt install lcov
+git clone https://github.com/aosedge/aos_core_cpp.git
+cd aos_core_cpp
+```
+
+## Prepare build environment
+
+Install the build tools and the system libraries required to build the dependencies (Conan builds some of them from
+source) and the AosCore components:
+
+```console
+sudo apt install build-essential cmake pkg-config autoconf automake libtool \
+    libseccomp-dev libyajl-dev libcap-dev libsystemd-dev \
+    libnl-3-dev libnl-route-3-dev libnftables-dev \
+    libblkid-dev libefivar-dev libefiboot-dev \
+    softhsm2 lcov
 pip install conan
 ```
+
+`cmake` version 3.23 or greater is required. The version shipped with Ubuntu 22.04 (3.22) is too old. Install a newer
+one, for example via `pip install cmake` or the [Kitware APT repository](https://apt.kitware.com/).
 
 `lcov` version 2.0 or greater is required. If your Linux distributive doesn't contain the required version, download and
 install the required version manually. For example in Ubuntu 22.04 it can be installed as following:
@@ -18,6 +35,7 @@ install the required version manually. For example in Ubuntu 22.04 it can be ins
 ```console
 wget https://launchpad.net/ubuntu/+source/lcov/2.0-4ubuntu2/+build/27959742/+files/lcov_2.0-4ubuntu2_all.deb
 sudo dpkg -i lcov_2.0-4ubuntu2_all.deb
+sudo apt-get install -f
 ```
 
 ## Build for host

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 # AosCore C++ implementation
 
+This repository contains the AosCore services: communication manager (CM), identity and access manager (IAM), message
+proxy (MP) and service manager (SM).
+
+This document is a from-scratch build guide. Start with [Get the sources](#get-the-sources) and
+[Prepare build environment](#prepare-build-environment).
+
+For a quick build with the default options use `./build.sh build`. For a custom configuration (a subset of
+services, a `Release` build, etc.) use the
+[manual build with individual CMake options](#custom-build-with-individual-cmake-options).
+
 ## Get the sources
 
 ```console
@@ -12,25 +22,60 @@ git clone https://github.com/aosedge/aos_core_cpp.git
 cd aos_core_cpp
 ```
 
+The build depends on two more Aos repositories — `aos_core_lib_cpp` and `aos_core_api`. They are fetched automatically
+at configure time (via CMake `FetchContent`) into the directory pointed to by `AOS_CORE_DIR` (`build/core` by default),
+so `git` and network access must be available on the host. To build against local checkouts instead, see
+`AOS_CORE_DIR` / `--core-dir` below.
+
 ## Prepare build environment
 
-Install the build tools and the system libraries required to build the dependencies (Conan builds some of them from
-source) and the AosCore components:
+The instructions below target Ubuntu. Other distributions provide the same packages under similar names.
+
+* Install the build tools and libraries:
 
 ```console
-sudo apt install build-essential cmake pkg-config autoconf automake libtool \
+sudo apt install build-essential git pkg-config autoconf automake libtool \
     libseccomp-dev libyajl-dev libcap-dev libsystemd-dev \
     libnl-3-dev libnl-route-3-dev libnftables-dev \
     libblkid-dev libefivar-dev libefiboot-dev \
     softhsm2 lcov
+```
+
+| Package group | Why it is needed |
+| --- | --- |
+| `build-essential`, `git` | C/C++ compiler, `make`, and fetching the external Aos repositories |
+| `pkg-config`, `autoconf`, `automake`, `libtool` | build the `crun` Conan dependency from source |
+| `libseccomp-dev`, `libyajl-dev`, `libcap-dev`, `libsystemd-dev` | `crun` build dependencies |
+| `libnl-3-dev`, `libnl-route-3-dev`, `libnftables-dev` | required by the SM / CM network code |
+| `libblkid-dev`, `libefivar-dev`, `libefiboot-dev` | required by the SM boot runtime |
+| `softhsm2` | provides `libsofthsm2`, required by the crypto unit tests (`WITH_TEST=ON`) |
+
+* Install `conan` (package manager for the external dependencies, e.g. gRPC, OpenSSL, Poco, libcurl, crun):
+
+```console
 pip install conan
 ```
 
-`cmake` version 3.23 or greater is required. The version shipped with Ubuntu 22.04 (3.22) is too old. Install a newer
-one, for example via `pip install cmake` or the [Kitware APT repository](https://apt.kitware.com/).
+* Install `cmake` (version 3.23 or greater is required):
 
-`lcov` version 2.0 or greater is required. If your Linux distributive doesn't contain the required version, download and
-install the required version manually. For example in Ubuntu 22.04 it can be installed as following:
+```console
+pip install cmake
+```
+
+The `cmake` shipped with Ubuntu 22.04 (3.22) is too old. On Ubuntu 24.04 the distribution `cmake` (3.28) is new enough,
+so you may use `sudo apt install cmake` instead. The [Kitware APT repository](https://apt.kitware.com/) is another
+option for an up-to-date `cmake`.
+
+* Install `lcov`:
+
+```console
+sudo apt install lcov
+```
+
+`lcov` is required to generate the code coverage report. It is also required to **configure** the project with
+`./build.sh build`, because that script always enables the coverage target. Without `lcov` the configuration step
+fails with `lcov not found`. Version 2.0 or greater is required. The version shipped with Ubuntu 22.04 (1.x) is
+too old; in that case download and install it manually:
 
 ```console
 wget https://launchpad.net/ubuntu/+source/lcov/2.0-4ubuntu2/+build/27959742/+files/lcov_2.0-4ubuntu2_all.deb
@@ -38,40 +83,81 @@ sudo dpkg -i lcov_2.0-4ubuntu2_all.deb
 sudo apt-get install -f
 ```
 
-## Build for host
+The last `apt-get install -f` step pulls in the Perl dependencies that the `.deb` requires.
 
-To make a build for host please run:
+## Build with build.sh
+
+`build.sh` is the recommended entry point. To make a build for host, run:
 
 ```console
 ./build.sh build
 ```
 
-It installs all external dependencies to conan, creates `./build` directory, builds the AoCore components with unit
-tests and coverage calculation target.
+It fetches the external Aos repositories, installs all external dependencies via Conan (some of them, like `crun`, are
+built from source), creates the `./build` directory and builds the AosCore components with the unit test and coverage
+targets. The configuration used by `build.sh build` is fixed: all services are enabled, `WITH_TEST=ON`,
+`WITH_COVERAGE=ON` and `WITH_VCHAN=OFF`.
 
-It is also possible to customize the build using different cmake options:
+`build.sh` accepts the following commands:
+
+| Command | Description |
+| --- | --- |
+| `build` | configures and builds the project |
+| `test` | runs the unit tests (see [Run unit tests](#run-unit-tests)) |
+| `coverage` | runs the tests and collects coverage (see [Check coverage](#check-coverage)) |
+| `lint` | runs static analysis with `cppcheck` |
+| `doc` | generates the documentation (see [Generate documentation](#generate-documentation)) |
+
+And the following options:
+
+| Option | Description |
+| --- | --- |
+| `--clean` | removes the `./build` directory before building |
+| `--aos-service <services>` | builds only the listed services, e.g. `--aos-service sm,mp,iam` (default: all) |
+| `--core-dir <path>` | path to local `aos_core_lib_cpp` / `aos_core_api` checkouts (sets `AOS_CORE_DIR`) |
+| `--ci` | builds through `build-wrapper` for CI / SonarQube analysis |
+| `--parallel <N>` | number of parallel build jobs (default: all available cores) |
+| `--build-type <type>` | `Debug` (default), `Release`, `RelWithDebInfo` or `MinSizeRel` |
+
+Example — a clean `Release` build of the service manager and IAM only:
 
 ```console
-cd build/
-conan install ../conan/ --output-folder . --settings=build_type=Debug --build=missing
-cmake .. -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake -DWITH_TEST=ON -DCMAKE_BUILD_TYPE=Debug
+./build.sh build --clean --aos-service sm,iam --build-type Release
 ```
 
-Cmake options:
+## Custom build with individual CMake options
+
+If you need options that `build.sh` does not expose, run Conan and CMake manually. From the repository root:
+
+```console
+mkdir -p build
+cd build
+conan install ../conan/ --output-folder . --settings=build_type=Debug --build=missing
+cmake .. -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake -DWITH_TEST=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build . --parallel
+```
+
+`conan install` generates `conan_toolchain.cmake` and provides the external dependencies; the `cmake` configure step
+must therefore be run with that toolchain file.
+
+CMake options:
 
 | Option | Value | Default | Description |
 | --- | --- | --- | --- |
-| `AOS_EXTERNAL_DIR` | `path/to/core to` | `build/core` | Aos core lib and API directory path |
+| `AOS_CORE_DIR` | `path/to/core` | `core` | directory for the fetched `aos_core_lib_cpp` and `aos_core_api` |
 | `WITH_CM` | `ON`, `OFF` | `ON` | build AosCore communication manager (CM) |
 | `WITH_IAM` | `ON`, `OFF` | `ON` | build AosCore identity and access manager (IAM) |
 | `WITH_MP` | `ON`, `OFF` | `ON` | build AosCore message proxy (MP) |
 | `WITH_SM` | `ON`, `OFF` | `ON` | build AosCore service manager (SM) |
-| `WITH_VCHAN` | `ON`, `OFF` | `ON` | use Xen vchan as communication transport for MP |
-| `WITH_TEST` | `ON`, `OFF` | `OFF` | creates unit tests target |
-| `WITH_COVERAGE` | `ON`, `OFF` | `OFF` | creates coverage calculation target |
-| `WITH_DOC` | `ON`, `OFF` | `OFF` | creates documentation target |
+| `WITH_VCHAN` | `ON`, `OFF` | `ON` | use Xen vchan as communication transport for MP (needs Xen libs) |
+| `WITH_TEST` | `ON`, `OFF` | `OFF` | creates unit tests target (requires `softhsm2`) |
+| `WITH_COVERAGE` | `ON`, `OFF` | `OFF` | creates coverage calculation target (requires `lcov`) |
+| `WITH_DOC` | `ON`, `OFF` | `OFF` | creates documentation target (requires `doxygen`) |
 
-Cmake variables:
+`AOS_CORE_DIR` is relative to the build directory unless an absolute path is given. `WITH_VCHAN=ON` requires the Xen
+vchan development libraries; `build.sh` disables it (`WITH_VCHAN=OFF`) for a host build.
+
+CMake variables:
 
 | Variable | Description |
 | --- | --- |
@@ -88,7 +174,8 @@ Build and run:
 
 ## Check coverage
 
-`lcov` utility shall be installed on your host to run this target. See [this chapter](#prepare-build-environment).
+`lcov` utility shall be installed on your host to run this target. See
+[Prepare build environment](#prepare-build-environment).
 
 Build and run:
 


### PR DESCRIPTION
Building on a clean Ubuntu 22.04 fails following the current README: the git clone step is absent, cmake is not mentioned (and the apt version is too old), the lcov 2.0 dpkg install needs a dependency fix, and a number of system libraries required by Conan (to build crun from source) and by the AosCore components (softhsm2, libnl, libnftables, blkid, efivar/efiboot) are not listed.

Document the clone step, the full apt package list, the cmake version requirement, and the 'apt-get install -f' fix for lcov 2.0.