### PR TITLE
common: cloudprotocol: adapt to pointer-based UnitInstanceStatusArray

### DIFF
--- a/src/common/cloudprotocol/tests/unitstatus.cpp
+++ b/src/common/cloudprotocol/tests/unitstatus.cpp
@@ -22,6 +22,13 @@ namespace aos::common::cloudprotocol {
 
 namespace {
 
+static StaticArray<UnitInstanceStatus, cMaxNumInstances> sInstanceStatusStorage;
+
+void ResetInstanceStatusStorage()
+{
+    sInstanceStatusStorage.Clear();
+}
+
 void SetArchInfo(const String& arch, const Optional<StaticString<cCPUVariantLen>>& variant, ArchInfo& archInfo)
 {
     archInfo.mArchitecture = arch;
@@ -54,7 +61,11 @@ void SetChecksum(const std::string& str, Array<uint8_t>& checksum)
 
 class CloudProtocolUnitStatus : public Test {
 public:
-    void SetUp() override { tests::utils::InitLog(); }
+    void SetUp() override
+    {
+        tests::utils::InitLog();
+        ResetInstanceStatusStorage();
+    }
 };
 
 /***********************************************************************************************************************
@@ -292,19 +303,29 @@ TEST_F(CloudProtocolUnitStatus, Instances)
     unitStatus->mInstances->Back().mSubjectID = "subjectID1";
     unitStatus->mInstances->Back().mVersion   = "version1";
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 1;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eActive;
-    SetChecksum("12345678", unitStatus->mInstances->Back().mInstances.Back().mStateChecksum);
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 1;
+        inst.mNodeID    = "nodeID1";
+        inst.mRuntimeID = "runtimeID1";
+        inst.mState     = InstanceStateEnum::eActive;
+        SetChecksum("12345678", inst.mStateChecksum);
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 2;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eFailed;
-    unitStatus->mInstances->Back().mInstances.Back().mError     = ErrorEnum::eFailed;
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 2;
+        inst.mNodeID    = "nodeID1";
+        inst.mRuntimeID = "runtimeID1";
+        inst.mState     = InstanceStateEnum::eFailed;
+        inst.mError     = ErrorEnum::eFailed;
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
     unitStatus->mInstances->EmplaceBack();
     unitStatus->mInstances->Back().mItemID    = "itemID2";
@@ -312,11 +333,16 @@ TEST_F(CloudProtocolUnitStatus, Instances)
     unitStatus->mInstances->Back().mSubjectID = "subjectID2";
     unitStatus->mInstances->Back().mVersion   = "version2";
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 1;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID2";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID2";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eActivating;
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 1;
+        inst.mNodeID    = "nodeID2";
+        inst.mRuntimeID = "runtimeID2";
+        inst.mState     = InstanceStateEnum::eActivating;
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
     auto json = Poco::makeShared<Poco::JSON::Object>(Poco::JSON_PRESERVE_KEY_ORDER);
 
@@ -351,19 +377,29 @@ TEST_F(CloudProtocolUnitStatus, PreinstalledInstances)
     unitStatus->mInstances->Back().mSubjectID = "subjectID1";
     unitStatus->mInstances->Back().mVersion   = "version1";
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 1;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eActive;
-    SetChecksum("12345678", unitStatus->mInstances->Back().mInstances.Back().mStateChecksum);
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 1;
+        inst.mNodeID    = "nodeID1";
+        inst.mRuntimeID = "runtimeID1";
+        inst.mState     = InstanceStateEnum::eActive;
+        SetChecksum("12345678", inst.mStateChecksum);
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 2;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID1";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eFailed;
-    unitStatus->mInstances->Back().mInstances.Back().mError     = ErrorEnum::eFailed;
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 2;
+        inst.mNodeID    = "nodeID1";
+        inst.mRuntimeID = "runtimeID1";
+        inst.mState     = InstanceStateEnum::eFailed;
+        inst.mError     = ErrorEnum::eFailed;
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
     unitStatus->mInstances->EmplaceBack();
     unitStatus->mInstances->Back().mItemID       = "itemID2";
@@ -372,11 +408,16 @@ TEST_F(CloudProtocolUnitStatus, PreinstalledInstances)
     unitStatus->mInstances->Back().mVersion      = "version2";
     unitStatus->mInstances->Back().mPreinstalled = true;
 
-    unitStatus->mInstances->Back().mInstances.EmplaceBack();
-    unitStatus->mInstances->Back().mInstances.Back().mInstance  = 1;
-    unitStatus->mInstances->Back().mInstances.Back().mNodeID    = "nodeID2";
-    unitStatus->mInstances->Back().mInstances.Back().mRuntimeID = "runtimeID2";
-    unitStatus->mInstances->Back().mInstances.Back().mState     = InstanceStateEnum::eActivating;
+    {
+        ASSERT_TRUE(sInstanceStatusStorage.EmplaceBack().IsNone());
+        auto& inst      = sInstanceStatusStorage.Back();
+        inst            = {};
+        inst.mInstance  = 1;
+        inst.mNodeID    = "nodeID2";
+        inst.mRuntimeID = "runtimeID2";
+        inst.mState     = InstanceStateEnum::eActivating;
+        unitStatus->mInstances->Back().mInstances.PushBack(&inst);
+    }
 
     auto json = Poco::makeShared<Poco::JSON::Object>(Poco::JSON_PRESERVE_KEY_ORDER);
 

--- a/src/common/cloudprotocol/unitstatus.cpp
+++ b/src/common/cloudprotocol/unitstatus.cpp
@@ -247,35 +247,35 @@ Poco::JSON::Object::Ptr InstanceToJSON(const UnitInstancesStatuses& statuses)
 
         {
             AosIdentity identity;
-            identity.mCodename = instanceStatus.mNodeID.CStr();
+            identity.mCodename = instanceStatus->mNodeID.CStr();
 
             instanceJson->set("node", CreateAosIdentity(identity));
         }
 
         {
             AosIdentity identity;
-            identity.mCodename = instanceStatus.mRuntimeID.CStr();
+            identity.mCodename = instanceStatus->mRuntimeID.CStr();
 
             instanceJson->set("runtime", CreateAosIdentity(identity));
         }
 
-        instanceJson->set("instance", instanceStatus.mInstance);
+        instanceJson->set("instance", instanceStatus->mInstance);
 
-        if (!instanceStatus.mStateChecksum.IsEmpty()) {
+        if (!instanceStatus->mStateChecksum.IsEmpty()) {
             StaticString<crypto::cSHA256Size * 2> checksum;
 
-            auto err = checksum.ByteArrayToHex(instanceStatus.mStateChecksum);
+            auto err = checksum.ByteArrayToHex(instanceStatus->mStateChecksum);
             AOS_ERROR_CHECK_AND_THROW(err, "can't convert state checksum to JSON");
 
             instanceJson->set("stateChecksum", checksum.CStr());
         }
 
-        instanceJson->set("state", instanceStatus.mState.ToString().CStr());
+        instanceJson->set("state", instanceStatus->mState.ToString().CStr());
 
-        if (!instanceStatus.mError.IsNone()) {
+        if (!instanceStatus->mError.IsNone()) {
             auto errorInfo = Poco::makeShared<Poco::JSON::Object>(Poco::JSON_PRESERVE_KEY_ORDER);
 
-            auto err = ToJSON(instanceStatus.mError, *errorInfo);
+            auto err = ToJSON(instanceStatus->mError, *errorInfo);
             AOS_ERROR_CHECK_AND_THROW(err, "can't convert errorInfo to JSON");
 
             instanceJson->set("errorInfo", errorInfo);


### PR DESCRIPTION
UnitInstanceStatusArray now stores UnitInstanceStatus* instead of values. Update instance field access in InstanceToJSON to use arrow operator and update tests to allocate instances in a backing store and push pointers.