### PR TITLE
sm: journalalerts: fix alerts after journal rotate

### DIFF
--- a/src/sm/alerts/journalalerts.cpp
+++ b/src/sm/alerts/journalalerts.cpp
@@ -176,12 +176,15 @@ void JournalAlerts::MonitorJournal()
     while (true) {
         std::unique_lock lock {mMutex};
 
-        auto stopped = mCondVar.wait_for(lock, journalWaitTimeout, [this] { return mStopped; });
-        if (stopped) {
-            return;
-        }
-
         try {
+            const auto waitTimeout = std::chrono::duration_cast<std::chrono::microseconds>(journalWaitTimeout);
+            const auto remaining   = mJournal->Wait(waitTimeout);
+
+            auto stopped = mCondVar.wait_for(lock, remaining, [this] { return mStopped; });
+            if (stopped) {
+                return;
+            }
+
             ProcessJournal();
             journalWaitTimeout = cWaitJournalTimeout;
         } catch (const std::exception& e) {

--- a/src/sm/alerts/tests/alerts.cpp
+++ b/src/sm/alerts/tests/alerts.cpp
@@ -127,16 +127,17 @@ void JournalAlertsTest::Init()
 
 void JournalAlertsTest::Start()
 {
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch(StartsWith("PRIORITY="))).Times(mConfig.mSystemAlertPriority + 1);
-    EXPECT_CALL(mJournalAlerts.mJournal, AddDisjunction());
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch("_SYSTEMD_UNIT=init.scope"));
-    EXPECT_CALL(mJournalAlerts.mJournal, SeekTail());
-    EXPECT_CALL(mJournalAlerts.mJournal, Previous());
+    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch(StartsWith("PRIORITY="))).Times(AnyNumber());
+    EXPECT_CALL(mJournalAlerts.mJournal, AddDisjunction()).Times(AnyNumber());
+    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch("_SYSTEMD_UNIT=init.scope")).Times(AnyNumber());
+    EXPECT_CALL(mJournalAlerts.mJournal, SeekTail()).Times(AnyNumber());
+    EXPECT_CALL(mJournalAlerts.mJournal, Previous()).Times(AnyNumber());
 
-    EXPECT_CALL(mStorage, GetJournalCursor(_)).WillOnce(DoAll(SetArgReferee<0>(mCursor.c_str()), Return(Error())));
+    EXPECT_CALL(mStorage, GetJournalCursor(_))
+        .WillOnce(DoAll(SetArgReferee<0>(mCursor.c_str()), Return(Error())))
+        .WillRepeatedly(DoAll(SetArgReferee<0>(""), Return(Error())));
 
     EXPECT_CALL(mJournalAlerts.mJournal, SeekCursor(mCursor.c_str())).RetiresOnSaturation();
-    EXPECT_CALL(mJournalAlerts.mJournal, Next());
 
     ASSERT_TRUE(mJournalAlerts.Start().IsNone());
 }
@@ -173,6 +174,10 @@ void JournalAlertsTest::WaitForAlert(std::chrono::milliseconds timeout)
 TEST_F(JournalAlertsTest, SetupJournal)
 {
     Init();
+
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next()).Times(AnyNumber());
+
     Start();
     Stop();
 }
@@ -180,9 +185,13 @@ TEST_F(JournalAlertsTest, SetupJournal)
 TEST_F(JournalAlertsTest, FailSaveCursor)
 {
     Init();
+
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next()).Times(AnyNumber());
+
     Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillOnce(Return("cursor"));
+    EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
     EXPECT_CALL(mStorage, SetJournalCursor(String("cursor"))).WillOnce(Return(Error(ErrorEnum::eFailed)));
 
     EXPECT_FALSE(mJournalAlerts.Stop().IsNone());
@@ -191,9 +200,12 @@ TEST_F(JournalAlertsTest, FailSaveCursor)
 TEST_F(JournalAlertsTest, SendServiceAlert)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
 
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
@@ -217,6 +229,8 @@ TEST_F(JournalAlertsTest, SendServiceAlert)
     EXPECT_CALL(mSender, SendAlert(MatchVariant(alert)))
         .WillOnce(InvokeWithoutArgs(this, &JournalAlertsTest::NotifyAlertSent));
 
+    Start();
+
     WaitForAlert();
 
     Stop();
@@ -225,9 +239,12 @@ TEST_F(JournalAlertsTest, SendServiceAlert)
 TEST_F(JournalAlertsTest, SendCoreAlert)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
     utils::JournalEntry entry = {};
@@ -243,6 +260,8 @@ TEST_F(JournalAlertsTest, SendCoreAlert)
     EXPECT_CALL(mSender, SendAlert(MatchVariant(alert)))
         .WillOnce(InvokeWithoutArgs(this, &JournalAlertsTest::NotifyAlertSent));
 
+    Start();
+
     WaitForAlert();
     Stop();
 }
@@ -250,9 +269,12 @@ TEST_F(JournalAlertsTest, SendCoreAlert)
 TEST_F(JournalAlertsTest, SendSystemAlertFiltered)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
     utils::JournalEntry entry = {};
@@ -263,16 +285,22 @@ TEST_F(JournalAlertsTest, SendSystemAlertFiltered)
     EXPECT_CALL(mJournalAlerts.mJournal, GetEntry()).WillOnce(Return(entry));
     EXPECT_CALL(mSender, SendAlert(_)).Times(0);
 
-    sleep(2);
+    Start();
+
+    sleep(0);
+
     Stop();
 }
 
 TEST_F(JournalAlertsTest, SendSystemAlert)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
     utils::JournalEntry entry = {};
@@ -287,6 +315,8 @@ TEST_F(JournalAlertsTest, SendSystemAlert)
     EXPECT_CALL(mSender, SendAlert(MatchVariant(alert)))
         .WillOnce(InvokeWithoutArgs(this, &JournalAlertsTest::NotifyAlertSent));
 
+    Start();
+
     WaitForAlert();
     Stop();
 }
@@ -294,9 +324,12 @@ TEST_F(JournalAlertsTest, SendSystemAlert)
 TEST_F(JournalAlertsTest, InitScopeTest)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
     utils::JournalEntry entry = {};
@@ -313,6 +346,8 @@ TEST_F(JournalAlertsTest, InitScopeTest)
     EXPECT_CALL(mSender, SendAlert(MatchVariant(alert)))
         .WillOnce(InvokeWithoutArgs(this, &JournalAlertsTest::NotifyAlertSent));
 
+    Start();
+
     WaitForAlert();
     Stop();
 }
@@ -320,9 +355,12 @@ TEST_F(JournalAlertsTest, InitScopeTest)
 TEST_F(JournalAlertsTest, EmptySystemdUnit)
 {
     Init();
-    Start();
 
-    EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
+    EXPECT_CALL(mJournalAlerts.mJournal, Next())
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor()).WillRepeatedly(Return("cursor"));
 
     utils::JournalEntry entry = {};
@@ -339,6 +377,8 @@ TEST_F(JournalAlertsTest, EmptySystemdUnit)
     EXPECT_CALL(mSender, SendAlert(MatchVariant(alert)))
         .WillOnce(InvokeWithoutArgs(this, &JournalAlertsTest::NotifyAlertSent));
 
+    Start();
+
     WaitForAlert();
     Stop();
 }
@@ -346,8 +386,8 @@ TEST_F(JournalAlertsTest, EmptySystemdUnit)
 TEST_F(JournalAlertsTest, RecoverJournalErrorOk)
 {
     Init();
-    Start();
 
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
     EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillRepeatedly(Return(false));
 
     // GetCursor failed
@@ -358,22 +398,18 @@ TEST_F(JournalAlertsTest, RecoverJournalErrorOk)
     // Restore journal
     EXPECT_CALL(mStorage, SetJournalCursor(String(""))).WillOnce(Return(ErrorEnum::eNone));
 
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch(StartsWith("PRIORITY="))).Times((mConfig.mSystemAlertPriority + 1));
-    EXPECT_CALL(mJournalAlerts.mJournal, AddDisjunction());
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch("_SYSTEMD_UNIT=init.scope"));
-    EXPECT_CALL(mJournalAlerts.mJournal, SeekTail());
-    EXPECT_CALL(mJournalAlerts.mJournal, Previous());
-    EXPECT_CALL(mStorage, GetJournalCursor(_)).WillOnce(DoAll(SetArgReferee<0>(""), Return(Error())));
+    Start();
 
-    sleep(2);
+    sleep(0);
+
     Stop();
 }
 
 TEST_F(JournalAlertsTest, RecoverJournalErrorFailed)
 {
     Init();
-    Start();
 
+    EXPECT_CALL(mJournalAlerts.mJournal, Wait(_)).WillRepeatedly(Return(std::chrono::microseconds::zero()));
     EXPECT_CALL(mJournalAlerts.mJournal, Next()).WillRepeatedly(Return(false));
 
     EXPECT_CALL(mJournalAlerts.mJournal, GetCursor())
@@ -382,14 +418,10 @@ TEST_F(JournalAlertsTest, RecoverJournalErrorFailed)
     // Restore journal
     EXPECT_CALL(mStorage, SetJournalCursor(String(""))).WillRepeatedly(Return(ErrorEnum::eNone));
 
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch(StartsWith("PRIORITY="))).Times(AnyNumber());
-    EXPECT_CALL(mJournalAlerts.mJournal, AddDisjunction()).Times(AnyNumber());
-    EXPECT_CALL(mJournalAlerts.mJournal, AddMatch("_SYSTEMD_UNIT=init.scope")).Times(AnyNumber());
-    EXPECT_CALL(mJournalAlerts.mJournal, SeekTail()).Times(AnyNumber());
-    EXPECT_CALL(mJournalAlerts.mJournal, Previous()).Times(AnyNumber());
-    EXPECT_CALL(mStorage, GetJournalCursor(_)).WillRepeatedly(DoAll(SetArgReferee<0>(""), Return(Error())));
+    Start();
 
-    sleep(4);
+    sleep(0);
+
     Stop();
 }
 

--- a/src/sm/logprovider/tests/stubs/journalstub.hpp
+++ b/src/sm/logprovider/tests/stubs/journalstub.hpp
@@ -98,6 +98,13 @@ public:
 
     std::string GetCursor() override { return ""; }
 
+    std::chrono::microseconds Wait(std::chrono::microseconds timeout) override
+    {
+        (void)timeout;
+
+        return std::chrono::microseconds::zero();
+    }
+
 private:
     std::vector<JournalEntry>           mJournal;
     std::vector<JournalEntry>::iterator mCurrentEntry  = mJournal.end();

--- a/src/sm/tests/mocks/journalmock.hpp
+++ b/src/sm/tests/mocks/journalmock.hpp
@@ -26,6 +26,7 @@ public:
     MOCK_METHOD(JournalEntry, GetEntry, (), (override));
     MOCK_METHOD(void, SeekCursor, (const std::string& cursor), (override));
     MOCK_METHOD(std::string, GetCursor, (), (override));
+    MOCK_METHOD(std::chrono::microseconds, Wait, (std::chrono::microseconds timeout), (override));
 };
 
 } // namespace aos::sm::utils

--- a/src/sm/utils/itf/journal.hpp
+++ b/src/sm/utils/itf/journal.hpp
@@ -9,6 +9,7 @@
 
 #include <core/common/tools/time.hpp>
 
+#include <chrono>
 #include <optional>
 #include <string>
 
@@ -127,6 +128,14 @@ public:
      * @return std::string.
      */
     virtual std::string GetCursor() = 0;
+
+    /**
+     * Waits for journal changes and processes them.
+     *
+     * @param timeout wait timeout.
+     * @return remaining time to wait.
+     */
+    virtual std::chrono::microseconds Wait(std::chrono::microseconds timeout) = 0;
 };
 
 } // namespace aos::sm::utils

--- a/src/sm/utils/journal.cpp
+++ b/src/sm/utils/journal.cpp
@@ -210,4 +210,19 @@ std::string Journal::GetCursor()
     return cursor;
 }
 
+std::chrono::microseconds Journal::Wait(std::chrono::microseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    if (const auto ret = sd_journal_wait(mJournal, 0); ret < 0) {
+        AOS_ERROR_THROW(ret, "can't wait journal");
+    }
+
+    const auto now       = std::chrono::steady_clock::now();
+    const auto remaining = deadline > now ? std::chrono::duration_cast<std::chrono::microseconds>(deadline - now)
+                                          : std::chrono::microseconds::zero();
+
+    return remaining;
+}
+
 } // namespace aos::sm::utils

--- a/src/sm/utils/journal.hpp
+++ b/src/sm/utils/journal.hpp
@@ -90,6 +90,14 @@ public:
      */
     std::string GetCursor() override;
 
+    /**
+     * Waits for journal changes and processes them.
+     *
+     * @param timeout wait timeout.
+     * @return remaining time to wait.
+     */
+    std::chrono::microseconds Wait(std::chrono::microseconds timeout) override;
+
 private:
     class sd_journal* mJournal {};
 };


### PR DESCRIPTION
Fix journal alerts after rotate: use sd_journal_wait (poll + sd_journal_process) in the monitor loop, because sd_journal_process() or any other sd_journal method does not detect rotation without polling the journal fd.