### PR TITLE
sm: launcher: container: return error on duplicate start/stop

### DIFF
--- a/src/sm/launcher/runtimes/container/container.cpp
+++ b/src/sm/launcher/runtimes/container/container.cpp
@@ -163,10 +163,7 @@ Error ContainerRuntime::StartInstance(const InstanceInfo& instanceInfo, Instance
                 instance->GetStatus(status);
 
                 if (status.mState == InstanceStateEnum::eActive) {
-                    LOG_DBG() << "Instance is already running"
-                              << Log::Field("instance", static_cast<const InstanceIdent&>(instanceInfo));
-
-                    return ErrorEnum::eNone;
+                    return ErrorEnum::eAlreadyExist;
                 }
             }
         }
@@ -220,9 +217,7 @@ Error ContainerRuntime::StopInstance(const InstanceIdent& instanceIdent, Instanc
 
             auto it = mCurrentInstances.find(static_cast<const InstanceIdent&>(instanceIdent));
             if (it == mCurrentInstances.end()) {
-                LOG_DBG() << "Instance is not running" << Log::Field("instance", instanceIdent);
-
-                return ErrorEnum::eNone;
+                return ErrorEnum::eNotFound;
             }
 
             instance = it->second;

--- a/src/sm/launcher/runtimes/container/tests/container.cpp
+++ b/src/sm/launcher/runtimes/container/tests/container.cpp
@@ -327,7 +327,7 @@ TEST_F(ContainerRuntimeTest, StartInstance)
     // Start the same instance again
 
     err = mRuntime.StartInstance(instance, *status);
-    EXPECT_TRUE(err.IsNone()) << "Failed to start instance: " << tests::utils::ErrorToStr(err);
+    EXPECT_TRUE(err.Is(ErrorEnum::eAlreadyExist)) << "Unexpected error: " << tests::utils::ErrorToStr(err);
 }
 
 TEST_F(ContainerRuntimeTest, StopInstance)
@@ -379,7 +379,7 @@ TEST_F(ContainerRuntimeTest, StopInstance)
     // Stop the same instance again
 
     err = mRuntime.StopInstance(static_cast<const InstanceIdent&>(instance), *status);
-    EXPECT_TRUE(err.IsNone()) << "Failed to stop instance: " << tests::utils::ErrorToStr(err);
+    EXPECT_TRUE(err.Is(ErrorEnum::eNotFound)) << "Unexpected error: " << tests::utils::ErrorToStr(err);
 }
 
 TEST_F(ContainerRuntimeTest, UpdateInstanceStatus)


### PR DESCRIPTION
Starting an instance that is already active now returns eAlreadyExist instead of silently succeeding, and stopping an instance that is not running now returns eNotFound instead of silently succeeding. This lets callers distinguish a no-op from an actual state transition.