### PR TITLE
common: utils: fix change owner fail on a symbolic link

### DIFF
--- a/src/common/utils/filesystem.cpp
+++ b/src/common/utils/filesystem.cpp
@@ -81,7 +81,7 @@ RetWithError<uintmax_t> CalculateSize(const std::string& path)
 void ChangeOwner(const std::string& path, uid_t uid, gid_t gid)
 {
     auto changeOwner = [](const std::string& path, uid_t uid, gid_t gid) {
-        if (chown(path.c_str(), uid, gid) == -1) {
+        if (lchown(path.c_str(), uid, gid) == -1) {
             AOS_ERROR_THROW(errno, "can't change file owner");
         }
     };


### PR DESCRIPTION
Use lchown instead of chown to change the owner of a symbolic link itself, rather than the file it points to. AosCore layers, for example, might a fully qualified path in a link, and this path exists only in this layer.