### PR TITLE
sm: laucher: runtimes: container: log error on burst limit exceeded

### DIFF
--- a/src/sm/launcher/runtimes/container/runner.cpp
+++ b/src/sm/launcher/runtimes/container/runner.cpp
@@ -206,7 +206,7 @@ void Runner::SetInstancesToRestart()
 
             if (const auto burst = runningState.mParams.mStartBurst.GetValue();
                 burst > 0 && runningState.mRestartCount >= burst) {
-                LOG_WRN() << "Restart burst limit exceeded, stopping restart attempts"
+                LOG_ERR() << "Restart burst limit exceeded, stopping restart attempts"
                           << Log::Field("instanceID", instanceID.c_str());
 
                 runningState.mExceedsBurstLimit = true;


### PR DESCRIPTION
This patch sets log severity to error when burst limit is exceeded, so the error is displayed in cloud as an alert.