### PR TITLE
systemd: rename service descriptions to AosCore

### DIFF
--- a/systemd/aos-cm.service.in
+++ b/systemd/aos-cm.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Communication Manager
+Description=AosCore Communication Manager
 Wants=network-online.target aos-iam.service
 After=network-online.target aos-iam.service
 ConditionPathExists=/var/aos/.provisionstate

--- a/systemd/aos-iam-prov.service.in
+++ b/systemd/aos-iam-prov.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Identity and Access Manager
+Description=AosCore Identity and Access Manager
 Wants=network-online.target
 After=network-online.target
 ConditionPathExists=!/var/aos/.provisionstate

--- a/systemd/aos-iam.service.in
+++ b/systemd/aos-iam.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Identity and Access Manager
+Description=AosCore Identity and Access Manager
 Wants=network-online.target
 After=network-online.target
 ConditionPathExists=/var/aos/.provisionstate

--- a/systemd/aos-mp-prov.service.in
+++ b/systemd/aos-mp-prov.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Message Proxy
+Description=AosCore Message Proxy
 Wants=network-online.target aos-iam.service
 After=network-online.target aos-iam.service
 ConditionPathExists=!/var/aos/.provisionstate

--- a/systemd/aos-mp.service.in
+++ b/systemd/aos-mp.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Message Proxy
+Description=AosCore Message Proxy
 Wants=network-online.target aos-iam.service
 After=network-online.target aos-iam.service
 ConditionPathExists=/var/aos/.provisionstate

--- a/systemd/aos-nftables.service.in
+++ b/systemd/aos-nftables.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Aos base nftables ruleset (fail-closed forward default-drop)
+Description=AosCore base nftables ruleset (fail-closed forward default-drop)
 Wants=network-pre.target
 Before=network-pre.target aos-sm.service
 After=sysinit.target

--- a/systemd/aos-sm.service.in
+++ b/systemd/aos-sm.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=AOS Service Manager
+Description=AosCore Service Manager
 Wants=network-online.target dbus.service aos-iam.service
 After=network-online.target dbus.service aos-iam.service
 ConditionPathExists=/var/aos/.provisionstate

--- a/systemd/aos.target
+++ b/systemd/aos.target
@@ -1,5 +1,5 @@
 [Unit]
-Description=Aos services
+Description=AosCore services
 After=aos-cm.service aos-sm.service aos-iam.service
 Wants=aos-cm.service aos-sm.service aos-iam.service
 


### PR DESCRIPTION
Update the Description field in all systemd unit files to use the AosCore naming instead of AOS/Aos, aligning unit metadata with the project's current name.